### PR TITLE
[feat/#5] 채팅 url db에 저장

### DIFF
--- a/chatting.py
+++ b/chatting.py
@@ -1,0 +1,63 @@
+import pandas as pd
+import pymysql
+import yaml
+from pathlib import Path
+from glob import glob
+
+def load_db_config(file_path):
+    with open(file_path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f).get("database")
+
+def get_connection(cfg):
+    return pymysql.connect(
+        host=cfg["host"],
+        user=cfg["user"],
+        password=cfg["password"],
+        db=cfg["database"],
+        charset="utf8mb4",
+        cursorclass=pymysql.cursors.DictCursor,
+        autocommit=False,
+    )
+
+def read_chatting_csv(csv_path: str) -> pd.DataFrame:
+    return pd.read_csv(csv_path)
+
+def insert_urls(conn, urls, batch_size=1000):
+    if not urls:
+        return
+    sql = "INSERT IGNORE INTO chatting (chatting_url) VALUES (%s)"
+    with conn.cursor() as cur:
+        for i in range(0, len(urls), batch_size):
+            cur.executemany(sql, [(u,) for u in urls[i:i+batch_size]])
+
+def files_to_process(path_str: str):
+    p = Path(path_str)
+    if p.is_file():
+        return [str(p)]
+    if p.is_dir():
+        return sorted(glob(str(p / "*.csv")))
+    return []
+
+def main():
+    csv_path_or_dir = "C:\\mateball_crawling\\chatting.csv"
+    db_config_path = "C:\\mateball_crawling\\MATEBALL_DATA\\db_config.yaml"
+
+    cfg = load_db_config(db_config_path)
+    conn = get_connection(cfg)
+
+    try:
+        for fp in files_to_process(csv_path_or_dir):
+            df = read_chatting_csv(fp)
+            if "chatting_url" not in df.columns:
+                raise ValueError("CSV에 chatting_url 컬럼이 없습니다.")
+            urls = df["chatting_url"].dropna().astype(str).str.strip().tolist()
+            insert_urls(conn, urls, batch_size=1000)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #5 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 스프레드 시트 내용 csv 파일로 저장
- 채팅 url 실제 DB에 삽입
```
def insert_urls(conn, urls, batch_size=1000):
    if not urls:
        return
    sql = "INSERT IGNORE INTO chatting (chatting_url) VALUES (%s)"
    with conn.cursor() as cur:
        for i in range(0, len(urls), batch_size):
            cur.executemany(sql, [(u,) for u in urls[i:i+batch_size]])
```
<br/>
- 중복 url은 저장하지 않도록 처리


### ❤️ To 다진 / To 헤음

---


- 앞으로 채팅 url 추가되면 해당 파일 실행만해주면됩니당

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adds a CSV-to-database importer for chat URLs.
  - Supports importing from a single file or all CSVs in a folder.
  - Validates required column with a localized error when missing.
  - Normalizes values, skips duplicates, and performs batched inserts.
  - Uses transactional commits with rollback on errors.
  - Reads database settings from a configuration file.

- Change
  - Crawl target months reduced to October 2025 only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->